### PR TITLE
Re-Enable SWC Minify

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 });
 
 module.exports = withBundleAnalyzer({
-  swcMinify: false,
+  swcMinify: true,
   images: {
     formats: ['image/avif', 'image/webp'],
     domains: ['images.ctfassets.net', 'api.mapbox.com', 'i.scdn.co'],


### PR DESCRIPTION
Issue with middleware when SWC minify is turned on seems to be fixed in next.js 12.0.8.