### PR TITLE
Fix validationErrors Inferrence and Simplify Types

### DIFF
--- a/src/lib/data/client/initialState.ts
+++ b/src/lib/data/client/initialState.ts
@@ -1,7 +1,6 @@
-import { FormActionResult } from "../types";
+import { Result } from "../types";
 
-// Use FormActionResult because it is the more restricted type
-export const initalState: FormActionResult<any, any> = {
+export const initalState: Result<any, any> = {
   status: "initial",
   id: "",
   data: null,

--- a/src/lib/data/client/useFormAction.tsx
+++ b/src/lib/data/client/useFormAction.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import { useFormState, useFormStatus } from "react-dom";
 import { z } from "zod";
-import { InferValidationErrors, ServerFormAction } from "../types";
+import { InferValidationErrors, Result, ServerFormAction } from "../types";
 import { initalState } from "./initialState";
 
 interface FormStatusProps {
@@ -41,8 +41,13 @@ export const useFormAction = <
     onSettled?: () => void;
   } = {},
 ) => {
-  const [state, formAction] = useFormState(action, initalState);
+  const [state, formAction] = useFormState<
+    Result<TInputSchema, TResponse>,
+    FormData
+  >(action, initalState);
   const [isRunning, setIsRunning] = useState(false);
+
+  if (isRunning) state.status = "running";
   const isSuccess = state.status === "success";
   const isError =
     state.status === "error" || state.status === "validationError";

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -62,23 +62,13 @@ export type ServerAction<
 
 // Form Action
 
-// FormActionResult is the same as Result, but the object with status of "running" is removed.
-export type FormActionResult<
-  TInputSchema extends z.ZodTypeAny,
-  TResponse extends any,
-> = Result<TInputSchema, TResponse> extends infer R
-  ? R extends { status: "running" }
-    ? never
-    : R
-  : never;
-
 export type ServerFormAction<
   TInputSchema extends z.ZodTypeAny,
   TResponse extends any,
 > = (
-  previousState: FormActionResult<TInputSchema, TResponse>,
+  previousState: Result<TInputSchema, TResponse>,
   formData: FormData,
-) => Promise<FormActionResult<TInputSchema, TResponse>>;
+) => Promise<Result<TInputSchema, TResponse>>;
 
 // Query
 


### PR DESCRIPTION
* `validationErrors` are now correctly inferred.
* No dedicated `FormActionResult` type anymore as we can infer  the `running` state on the client.